### PR TITLE
Update sil_jarai.kmn

### DIFF
--- a/release/sil/sil_jarai/source/sil_jarai.kmn
+++ b/release/sil/sil_jarai/source/sil_jarai.kmn
@@ -59,6 +59,7 @@ group(main) using keys
 + [K_BKQUOTE] > '«'
 + [SHIFT K_BKQUOTE] > '»'
 + [RALT K_L] > ':'
++ [RALT K_BKQUOTE] > '~'
 + [RALT K_COMMA] > ','
 + [RALT K_PERIOD] > '.'
 + [RALT K_SLASH] > '/'
@@ -139,7 +140,7 @@ group(main) using keys
 c nul keys
 store(nulShiftKeys)  [SHIFT K_R] [SHIFT K_RBRKT] [SHIFT K_BKSLASH] [SHIFT K_PERIOD]
 store(nulDefaultKeys)   [K_RBRKT] [K_BKSLASH] 
-store(nulAltGrKeys) [RALT K_BKQUOTE] [RALT K_1] [RALT K_2] [RALT K_3] [RALT K_5] [RALT K_6] [RALT K_7] [RALT K_8] \
+store(nulAltGrKeys)  [RALT K_1] [RALT K_2] [RALT K_3] [RALT K_5] [RALT K_6] [RALT K_7] [RALT K_8] \
                     [RALT K_HYPHEN] [RALT K_EQUAL] [RALT K_Q] [RALT K_E] [RALT K_R] [RALT K_T] [RALT K_Y] [RALT K_U] \
                     [RALT K_I] [RALT K_O] [RALT K_P] [RALT K_A] [RALT K_S] [RALT K_D] [RALT K_F] [RALT K_G] [RALT K_H]\
                     [RALT K_H] [RALT K_J] [RALT K_Z] [RALT K_X] [RALT K_C] [RALT K_V] [RALT K_N] [RALT K_M]


### PR DESCRIPTION
Implementing request to enable tilde for desktop keyboard.
Adding RALT K_BKQUOTE to give tilde, also removing RALT K_BKQUOTE from nulALTGRKEYS store. 